### PR TITLE
feature #38: 큐브(잠재능력 재설정) 시뮬레이터 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,3 +73,31 @@ abbr:where([title]) {
   border-radius: 10px;
   padding: 3px;
 }
+
+.fade-in {
+  animation: fadein 0.5s;
+}
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.cube-glow {
+  animation: glowFadeout 1s ease-out;
+}
+
+@keyframes glowFadeout {
+  0% {
+    background-color: rgb(255, 255, 255, 0.3);
+    border: 2px solid rgb(65, 217, 255, 0.9);
+    box-shadow: 0 0 50px rgb(223, 245, 255);
+  }
+  100% {
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0);
+  }
+}

--- a/src/components/Container/CubeContainer.tsx
+++ b/src/components/Container/CubeContainer.tsx
@@ -1,0 +1,151 @@
+import { useCubeStore } from "@/stores/cube";
+import { ItemPotentialGrade } from "@/types/Equipment";
+import { CubeSimulator } from "@/utils/CubeSimulator";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
+
+export const CubeContainer = () => {
+  const targetItem = useCubeStore((state) => state.targetItem);
+  const resetCube = useCubeStore((state) => state.resetCube);
+  const { itemLevel, itemType, itemIcon, itemName, itemPotentialGrade, currentPotentialOptions } = targetItem || {};
+  const [prevOptions, setPrevOptions] = useState<string[]>([]);
+  const [newOptions, setNewOptions] = useState<string[]>([]);
+  const [prevGrade, setPrevGrade] = useState<ItemPotentialGrade>();
+  const [newGrade, setNewGrade] = useState<ItemPotentialGrade>();
+  const [currentAttempt, setCurrentAttempt] = useState<number>(0);
+  const [currentGuarantee, setCurrentGuarantee] = useState<number>(0);
+  const [fadeIn, setFadeIn] = useState(false);
+  const [glow, setGlow] = useState(false);
+
+  const remainGradeUpRatio = (() => {
+    if (currentGuarantee === 0) return 0;
+    return currentAttempt / currentGuarantee;
+  })();
+
+  useEffect(() => {
+    if (!currentPotentialOptions) return;
+
+    setPrevGrade(itemPotentialGrade);
+    setPrevOptions(currentPotentialOptions);
+  }, [currentPotentialOptions]);
+
+  const cubeSimulator = useRef(
+    new CubeSimulator({
+      itemGrade: itemPotentialGrade ?? "레어",
+      itemLevel: itemLevel ?? 0,
+      itemType: itemType ?? "무기",
+      itemOptions: currentPotentialOptions ?? [],
+    })
+  );
+
+  const handleRollCubeClick = () => {
+    cubeSimulator.current.rollCube();
+    const { prevOptions, currentOptions, prevGrade, currentGrade, currentAttempt, currentGuarantee } = cubeSimulator.current.getItemState();
+
+    setPrevOptions(prevOptions);
+    setNewOptions(currentOptions);
+    setPrevGrade(prevGrade);
+    setNewGrade(currentGrade);
+    setCurrentAttempt(currentAttempt);
+    setCurrentGuarantee(currentGuarantee);
+  };
+
+  useEffect(() => {
+    setFadeIn(true);
+
+    const timer = setTimeout(() => {
+      setFadeIn(false);
+    }, 500);
+
+    return () => {
+      setFadeIn(false);
+      clearTimeout(timer);
+    };
+  }, [newOptions]);
+
+  useEffect(() => {
+    if (!newGrade) return;
+    if (prevGrade === newGrade) return;
+
+    setGlow(true);
+    setTimeout(() => {
+      setGlow(false);
+    }, 1000);
+  }, [prevGrade, newGrade]);
+
+  if (!targetItem) return null;
+
+  return (
+    <>
+      <div
+        style={{ zIndex: 1002 }}
+        className={`fixed top-[30%] left-[50%] text-white flex rounded-lg
+             bg-black/80 border border-white/30 p-2 align-center 
+             justify-center w-[312px] ${glow ? "cube-glow" : ""}`}
+      >
+        <div className="flex p-1 flex-col items-center gap-2">
+          <p className="text-sm font-bold">아이템의 잠재능력을 재설정합니다.</p>
+          <div className="flex flex-col p-1 rounded-lg bg-gray-300 gap-2">
+            <div className="flex flex-col gap-2 items-center justify-center w-[280px] h-[90px] rounded-md bg-slate-700">
+              {itemIcon && (
+                <div>
+                  <Image
+                    style={{ imageRendering: "pixelated" }}
+                    src={itemIcon}
+                    alt={itemName || "cube-target"}
+                    unoptimized
+                    width={48}
+                    height={48}
+                  />
+                </div>
+              )}
+              <div className="flex border border-sky-700/50 bg-slate-800 w-[260px] relative h-3.5 rounded-sm">
+                <p
+                  className="absolute mx-auto text-xs font-extralight text-white"
+                  style={{ top: "50%", left: "50%", transform: "translate(-50%, -50%)" }}
+                >{`${currentAttempt} / ${currentGuarantee}`}</p>
+                <div
+                  style={{ width: `${remainGradeUpRatio * 100}%` }}
+                  className="flex bg-gradient-to-r from-sky-500 to-blue-600 h-3.5 rounded-sm"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col w-[280px] rounded-md bg-sky-500">
+              <p className="text-sm p-1 font-bold [text-shadow:_1px_2px_4px_rgb(0_0_0/_0.4)]">BEFORE</p>
+              <div className="flex flex-col bg-slate-900 m-1 p-1 text-sm rounded-md min-h-[88px]">
+                <p className="flex justify-center text-yellow-300 font-light">{prevGrade}</p>
+                {prevOptions?.map((option, idx) => (
+                  <p key={idx} className={`font-medium text-sm ${fadeIn ? "fade-in" : ""}`}>
+                    {option}
+                  </p>
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-col w-[280px] rounded-md bg-sky-500">
+              <p className="text-sm p-1 font-bold [text-shadow:_1px_2px_4px_rgb(0_0_0/_0.4)]">AFTER</p>
+              <div className="flex flex-col bg-slate-900 m-1 p-1 text-sm rounded-md min-h-[88px]">
+                <p className="flex justify-center text-yellow-300 font-light">{newGrade}</p>
+                {newOptions?.map((option, idx) => (
+                  <p key={idx} className={`font-medium text-sm ${fadeIn ? "fade-in" : ""}`}>
+                    {option}
+                  </p>
+                ))}
+              </div>
+            </div>
+            <button
+              onClick={handleRollCubeClick}
+              className="flex justify-center border border-lime-500 bg-lime-400 hover:bg-lime-500 text-sm font-bold text-black rounded-md p-1"
+            >
+              <p className="flex">한 번 더 재설정하기</p>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        style={{ zIndex: 1001 }}
+        onClick={resetCube}
+        className="fixed z-50 top-0 left-0 w-full h-full flex justify-center items-center opacity-50 bg-black"
+      />
+    </>
+  );
+};

--- a/src/components/Container/MainContainer.tsx
+++ b/src/components/Container/MainContainer.tsx
@@ -9,12 +9,16 @@ import { DimmedLayer } from "../DimmedLayer";
 import { useCharacterStore } from "@/stores/character";
 import { ExpContainer } from "./ExpContainer";
 import { EquipSetContainer } from "./EquipSetContainer";
+import { useCubeStore } from "@/stores/cube";
+import { CubeContainer } from "./CubeContainer";
 
 export const MainContainer = () => {
   const fetchStatus = useCharacterStore((state) => state.fetchStatus);
+  const cubeTargetItem = useCubeStore((state) => state.targetItem);
 
   return (
     <div className="main_container w-[1280px] gap-4">
+      {cubeTargetItem && <CubeContainer />}
       <StatContainer />
       <EquipContainer />
       <div className="grid gap-4">

--- a/src/components/Equip/EquipIcon/NormalEquipIcon.tsx
+++ b/src/components/Equip/EquipIcon/NormalEquipIcon.tsx
@@ -5,6 +5,7 @@ import { ItemEquipment } from "@/types/Equipment";
 import { StarIcon } from "../../svg/StarIcon";
 import { ItemIcon } from "./ItemIcon";
 import { EquipDetailCard } from "../EquiqDetailCard";
+import { CubeSimulator } from "@/utils/CubeSimulator";
 
 const StarForceBadge = ({ item }: { item: ItemEquipment }) => {
   const starforce = parseInt(item?.starforce);

--- a/src/components/Equip/EquiqDetailCard.tsx
+++ b/src/components/Equip/EquiqDetailCard.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useRef } from "react";
 import type { SymbolOption } from "@/types/SymbolEquipment";
 import type { AndroidEquipment } from "@/types/AndroidEquipment";
 import { NormalContainer } from "./normal/Container";
@@ -7,6 +7,7 @@ import { SymbolContainer } from "./symbol/Container";
 import { CharacterEquipments } from "@/hooks/useCharacterInfo";
 
 import { EquipContext } from "../Container/EquipContainer";
+import { CubeSimulator } from "@/utils/CubeSimulator";
 
 type DetailCardProps = { equipName: string; characterEquipments: CharacterEquipments };
 

--- a/src/components/Equip/normal/Container.tsx
+++ b/src/components/Equip/normal/Container.tsx
@@ -5,6 +5,9 @@ import { EquipDetailItem } from "./EquipDetailItem";
 import { equipOptionList } from "@/consts/EquipOptionList";
 import { StarforceBadge } from "../StarforceBadge";
 import { EquipDescription } from "./EquipDescription";
+import { MouseEvent, useContext, useRef } from "react";
+import { useCubeStore } from "@/stores/cube";
+import { EquipActionContext, EquipContext } from "@/components/Container/EquipContainer";
 
 type Props = {
   item: ItemEquipment;
@@ -14,6 +17,7 @@ export const NormalContainer = ({ item }: Props) => {
     starforce,
     item_icon,
     item_name,
+    item_equipment_slot,
     item_equipment_part,
     scroll_upgradeable_count,
     scroll_resilience_count,
@@ -33,6 +37,24 @@ export const NormalContainer = ({ item }: Props) => {
   const isAmazingForce = item.starforce_scroll_flag === "사용";
   const showStarforceBadge = !!item.starforce && item.starforce !== "0";
   const canCuttableItem = item.cuttable_count !== "255";
+
+  const setSelectedEquipName = useContext(EquipActionContext);
+  const setCubeTargetItem = useCubeStore((state) => state.setCubeTargetItem);
+  const handleRollCubeClick = (e: MouseEvent) => {
+    if (!potential_option_grade) return;
+    e.stopPropagation();
+    setSelectedEquipName("");
+    setCubeTargetItem({
+      targetItem: {
+        itemName: item_name,
+        itemIcon: item_icon,
+        itemLevel: base_equipment_level,
+        itemPotentialGrade: potential_option_grade,
+        itemType: item_equipment_slot,
+        currentPotentialOptions: [potential_option_1, potential_option_2, potential_option_3],
+      },
+    });
+  };
 
   return (
     <>
@@ -72,6 +94,14 @@ export const NormalContainer = ({ item }: Props) => {
           grade={additional_potential_option_grade}
           options={[additional_potential_option_1, additional_potential_option_2, additional_potential_option_3]}
         />
+      )}
+      {potential_option_grade && (
+        <button
+          onClick={handleRollCubeClick}
+          className="text-white text-sm font-bold p-1 mt-1 rounded-md bg-gradient-to-r from-purple-400/90 to-sky-500/90 hover:bg-gradient-to-r hover:from-purple-500/90 hover:to-sky-600/90"
+        >
+          🧊 잠재능력 재설정
+        </button>
       )}
     </>
   );

--- a/src/stores/cube.ts
+++ b/src/stores/cube.ts
@@ -1,0 +1,27 @@
+import type { ItemPotentialGrade } from "@/types/Equipment";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface CubeState {
+  targetItem: {
+    itemPotentialGrade: ItemPotentialGrade;
+    itemLevel: number;
+    itemType: string;
+    itemIcon: string;
+    itemName: string;
+    currentPotentialOptions?: string[];
+  } | null;
+}
+
+interface CubeAction {
+  setCubeTargetItem: (item: CubeState) => void;
+  resetCube: () => void;
+}
+
+export const useCubeStore = create<CubeState & CubeAction>()(
+  devtools((set) => ({
+    targetItem: null,
+    setCubeTargetItem: (item) => set(item),
+    resetCube: () => set({ targetItem: null }),
+  }))
+);

--- a/src/types/Equipment.ts
+++ b/src/types/Equipment.ts
@@ -65,6 +65,8 @@ type ItemEtcOption = {
 };
 type StarforceOption = ItemEtcOption;
 
+export type ItemPotentialGrade = "레어" | "에픽" | "유니크" | "레전드리";
+
 export type ItemEquipment = {
   item_equipment_part: string;
   item_equipment_slot: string;
@@ -76,8 +78,8 @@ export type ItemEquipment = {
   item_gender: string | null;
   item_total_option: TotalItemOption;
   item_base_option: BaseItemOption;
-  potential_option_grade: string;
-  additional_potential_option_grade: string;
+  potential_option_grade: ItemPotentialGrade | null;
+  additional_potential_option_grade: ItemPotentialGrade | null;
   /** 잠재능력 봉인 여부 */
   potential_option_flag: string;
   potential_option_1: string;

--- a/src/utils/CubeSimulator.ts
+++ b/src/utils/CubeSimulator.ts
@@ -1,5 +1,3 @@
-import { fail } from "assert";
-
 type ItemGrade = "레어" | "에픽" | "유니크" | "레전드리";
 
 type Constructor = {

--- a/src/utils/CubeSimulator.ts
+++ b/src/utils/CubeSimulator.ts
@@ -1,0 +1,473 @@
+import { fail } from "assert";
+
+type ItemGrade = "레어" | "에픽" | "유니크" | "레전드리";
+
+type Constructor = {
+  itemGrade: ItemGrade;
+  itemType: string;
+  itemLevel: number;
+  itemOptions: string[];
+};
+
+export class CubeSimulator {
+  private grades: ItemGrade[];
+  private gradeUpInfo: { chance: number; guarantee: number }[];
+  private gradeIndex = 0;
+  private failedAttempts = [0, 0, 0];
+
+  private currentAttempt = 0;
+  private currentGuarantee = 0;
+
+  private currentOptions = ["", "", ""];
+  private prevOptions = ["", "", ""];
+
+  private currentGrade: ItemGrade = "레어";
+  private prevGrade: ItemGrade = "레어";
+
+  private initialItemGrade: ItemGrade;
+  private initialItemOptions = ["", "", ""];
+  private itemType = "";
+  private itemLevel = "0";
+
+  constructor({ itemGrade, itemOptions, itemType, itemLevel }: Constructor) {
+    this.grades = ["레어", "에픽", "유니크", "레전드리"];
+    this.gradeUpInfo = [
+      { chance: 0.150000001275, guarantee: 10 }, // 레어 -> 에픽
+      { chance: 0.035, guarantee: 42 }, // 에픽 -> 유니크
+      { chance: 0.014, guarantee: 107 }, // 유니크 -> 레전드리
+    ];
+    this.initialItemGrade = itemGrade;
+    this.itemType = itemType;
+    this.itemLevel = this.convertItemLevelToString(itemLevel);
+    this.initialItemOptions = itemOptions;
+
+    this.reset(this.initialItemGrade, this.initialItemOptions);
+  }
+
+  convertItemLevelToString(itemLevel: number) {
+    if (itemLevel < 30) return "30";
+    if (itemLevel < 70) return "70";
+    if (itemLevel < 119) return "100";
+    if (itemLevel < 250) return "120";
+    return "250";
+  }
+
+  reset(itemGrade: ItemGrade, itemOptions: string[]) {
+    this.gradeIndex = this.grades.indexOf(itemGrade);
+    this.failedAttempts = [0, 0, 0]; // 각 등급별 실패 횟수
+    this.prevOptions = itemOptions ?? ["", "", ""]; // 옵션 초기화
+    this.currentOptions = itemOptions ?? ["", "", ""]; // 옵션 초기화
+    this.currentGuarantee = this.gradeUpInfo[this.gradeIndex]?.guarantee ?? 0;
+  }
+
+  rollCube() {
+    this.prevGrade = this.grades[this.gradeIndex];
+    if (this.gradeIndex < this.grades.length - 1) {
+      const gradeUpInfo = this.gradeUpInfo[this.gradeIndex];
+      const roll = Math.random();
+
+      if (roll < gradeUpInfo.chance || this.failedAttempts[this.gradeIndex] >= gradeUpInfo.guarantee) {
+        this.gradeIndex++;
+        this.failedAttempts[this.gradeIndex - 1] = 0; // 보장된 승급 시 초기화
+      } else {
+        this.failedAttempts[this.gradeIndex]++;
+      }
+    }
+    this.currentGrade = this.grades[this.gradeIndex];
+    this.currentAttempt = this.failedAttempts[this.gradeIndex] ?? 0;
+    this.currentGuarantee = this.gradeUpInfo[this.gradeIndex]?.guarantee ?? 0;
+    this.assignOptions();
+  }
+
+  assignOptions() {
+    this.prevOptions = this.currentOptions;
+
+    const optionPool = this.getOptionPool();
+    this.currentOptions = [
+      this.getRandomOption(optionPool.firstLine),
+      this.getRandomOption(optionPool.secondLine),
+      this.getRandomOption(optionPool.thirdLine),
+    ];
+  }
+
+  getOptionPool() {
+    return getItemOptionPool(this.itemType, this.grades[this.gradeIndex], this.itemLevel);
+  }
+
+  getRandomOption(optionPool: Option[]) {
+    const roll = Math.random();
+    let cumulativeProbability = 0;
+
+    for (const option of optionPool) {
+      cumulativeProbability += option.probability;
+      if (roll < cumulativeProbability) {
+        return option.name;
+      }
+    }
+    return "";
+  }
+
+  getItemState() {
+    return {
+      prevGrade: this.prevGrade,
+      currentGrade: this.currentGrade,
+      prevOptions: this.prevOptions,
+      currentOptions: this.currentOptions,
+      failedAttempts: this.failedAttempts,
+      currentAttempt: this.currentAttempt,
+      currentGuarantee: this.currentGuarantee,
+    };
+  }
+}
+
+type Option = { name: string; probability: number };
+type ItemOptions = { firstLine: Option[]; secondLine: Option[]; thirdLine: Option[] };
+
+function getItemOptionPool(itemType: string, itemGrade: ItemGrade, itemLevel: string): ItemOptions {
+  // 특정 아이템 타입과 레벨에 따라 옵션 풀을 결정
+  const optionPools: Record<string, Record<string, Record<string, ItemOptions>>> = {
+    무기: {
+      레어: {
+        "120": {
+          firstLine: [
+            { name: "STR: +12", probability: 0.061224 },
+            { name: "DEX: +12", probability: 0.061224 },
+            { name: "INT: +12", probability: 0.061224 },
+            { name: "LUK: +12", probability: 0.061224 },
+            { name: "최대 HP: +120", probability: 0.061224 },
+            { name: "최대 MP: +120", probability: 0.061224 },
+            { name: "공격력: +12", probability: 0.040816 },
+            { name: "마력: +12", probability: 0.040816 },
+            { name: "STR: +3%", probability: 0.061224 },
+            { name: "DEX: +3%", probability: 0.061224 },
+            { name: "INT: +3%", probability: 0.061224 },
+            { name: "LUK: +3%", probability: 0.061224 },
+            { name: "공격력: +3%", probability: 0.020408 },
+            { name: "마력: +3%", probability: 0.020408 },
+            { name: "크리티컬 확률: +4%", probability: 0.020408 },
+            { name: "데미지: +3%", probability: 0.020408 },
+            { name: "올스탯: +5", probability: 0.040816 },
+            { name: "공격 시 20% 확률로 240의 HP 회복", probability: 0.020408 },
+            { name: "공격 시 20% 확률로 120의 MP 회복", probability: 0.020408 },
+            { name: "공격 시 20% 확률로 6레벨 중독효과 적용", probability: 0.020408 },
+            { name: "공격 시 10% 확률로 2레벨 기절효과 적용", probability: 0.020408 },
+            { name: "공격 시 20% 확률로 2레벨 슬로우효과 적용", probability: 0.020408 },
+            { name: "공격 시 20% 확률로 3레벨 암흑효과 적용", probability: 0.020408 },
+            { name: "공격 시 10% 확률로 2레벨 빙결효과 적용", probability: 0.020408 },
+            { name: "공격 시 10% 확률로 2레벨 봉인효과 적용", probability: 0.020408 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.020408 },
+          ],
+          secondLine: [
+            { name: "STR: +6", probability: 0.109091 },
+            { name: "DEX: +6", probability: 0.109091 },
+            { name: "INT: +6", probability: 0.109091 },
+            { name: "LUK: +6", probability: 0.109091 },
+            { name: "최대 HP: +60", probability: 0.109091 },
+            { name: "최대 MP: +60", probability: 0.109091 },
+            { name: "공격력: +6", probability: 0.072727 },
+            { name: "마력: +6", probability: 0.072727 },
+            { name: "STR: +12", probability: 0.012245 },
+            { name: "DEX: +12", probability: 0.012245 },
+            { name: "INT: +12", probability: 0.012245 },
+            { name: "LUK: +12", probability: 0.012245 },
+            { name: "최대 HP: +120", probability: 0.012245 },
+            { name: "최대 MP: +120", probability: 0.012245 },
+            { name: "공격력: +12", probability: 0.008163 },
+            { name: "마력: +12", probability: 0.008163 },
+            { name: "STR: +3%", probability: 0.012245 },
+            { name: "DEX: +3%", probability: 0.012245 },
+            { name: "INT: +3%", probability: 0.012245 },
+            { name: "LUK: +3%", probability: 0.012245 },
+            { name: "공격력: +3%", probability: 0.004082 },
+            { name: "마력: +3%", probability: 0.004082 },
+            { name: "크리티컬 확률: +4%", probability: 0.004082 },
+            { name: "데미지: +3%", probability: 0.004082 },
+            { name: "올스탯: +5", probability: 0.008163 },
+            { name: "공격 시 20% 확률로 240의 HP 회복", probability: 0.004082 },
+            { name: "공격 시 20% 확률로 120의 MP 회복", probability: 0.004082 },
+            { name: "공격 시 20% 확률로 6레벨 중독효과 적용", probability: 0.004082 },
+            { name: "공격 시 10% 확률로 2레벨 기절효과 적용", probability: 0.004082 },
+            { name: "공격 시 20% 확률로 2레벨 슬로우효과 적용", probability: 0.004082 },
+            { name: "공격 시 20% 확률로 3레벨 암흑효과 적용", probability: 0.004082 },
+            { name: "공격 시 10% 확률로 2레벨 빙결효과 적용", probability: 0.004082 },
+            { name: "공격 시 10% 확률로 2레벨 봉인효과 적용", probability: 0.004082 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.004082 },
+          ],
+          thirdLine: [
+            { name: "STR: +6", probability: 0.129545 },
+            { name: "DEX: +6", probability: 0.129545 },
+            { name: "INT: +6", probability: 0.129545 },
+            { name: "LUK: +6", probability: 0.129545 },
+            { name: "최대 HP: +60", probability: 0.129545 },
+            { name: "최대 MP: +60", probability: 0.129545 },
+            { name: "공격력: +6", probability: 0.086364 },
+            { name: "마력: +6", probability: 0.086364 },
+            { name: "STR: +12", probability: 0.003061 },
+            { name: "DEX: +12", probability: 0.003061 },
+            { name: "INT: +12", probability: 0.003061 },
+            { name: "LUK: +12", probability: 0.003061 },
+            { name: "최대 HP: +120", probability: 0.003061 },
+            { name: "최대 MP: +120", probability: 0.003061 },
+            { name: "공격력: +12", probability: 0.002041 },
+            { name: "마력: +12", probability: 0.002041 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.00102 },
+          ],
+        },
+      },
+      에픽: {
+        "120": {
+          firstLine: [
+            { name: "STR: +6%", probability: 0.108696 },
+            { name: "DEX: +6%", probability: 0.108696 },
+            { name: "INT: +6%", probability: 0.108696 },
+            { name: "LUK: +6%", probability: 0.108696 },
+            { name: "최대 HP: +6%", probability: 0.108696 },
+            { name: "최대 MP: +6%", probability: 0.108696 },
+            { name: "공격력: +6%", probability: 0.043478 },
+            { name: "마력: +6%", probability: 0.043478 },
+            { name: "크리티컬 확률: +8%", probability: 0.043478 },
+            { name: "데미지: +6%", probability: 0.043478 },
+            { name: "올스탯: +3%", probability: 0.043478 },
+            { name: "공격 시 20% 확률로 360의 HP 회복", probability: 0.043478 },
+            { name: "공격 시 20% 확률로 180의 MP 회복", probability: 0.043478 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.043478 },
+          ],
+          secondLine: [
+            { name: "STR: +12", probability: 0.04898 },
+            { name: "DEX: +12", probability: 0.04898 },
+            { name: "INT: +12", probability: 0.04898 },
+            { name: "LUK: +12", probability: 0.04898 },
+            { name: "최대 HP: +120", probability: 0.04898 },
+            { name: "최대 MP: +120", probability: 0.04898 },
+            { name: "공격력: +12", probability: 0.032653 },
+            { name: "마력: +12", probability: 0.032653 },
+            { name: "STR: +3%", probability: 0.04898 },
+            { name: "DEX: +3%", probability: 0.04898 },
+            { name: "INT: +3%", probability: 0.04898 },
+            { name: "LUK: +3%", probability: 0.04898 },
+            { name: "공격력: +3%", probability: 0.016327 },
+            { name: "마력: +3%", probability: 0.016327 },
+            { name: "크리티컬 확률: +4%", probability: 0.016327 },
+            { name: "데미지: +3%", probability: 0.016327 },
+            { name: "올스탯: +5", probability: 0.032653 },
+            { name: "공격 시 20% 확률로 240의 HP 회복", probability: 0.016327 },
+            { name: "공격 시 20% 확률로 120의 MP 회복", probability: 0.016327 },
+            { name: "공격 시 20% 확률로 6레벨 중독효과 적용", probability: 0.016327 },
+            { name: "공격 시 10% 확률로 2레벨 기절효과 적용", probability: 0.016327 },
+            { name: "공격 시 20% 확률로 2레벨 슬로우효과 적용", probability: 0.016327 },
+            { name: "공격 시 20% 확률로 3레벨 암흑효과 적용", probability: 0.016327 },
+            { name: "공격 시 10% 확률로 2레벨 빙결효과 적용", probability: 0.016327 },
+            { name: "공격 시 10% 확률로 2레벨 봉인효과 적용", probability: 0.016327 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.016327 },
+            { name: "STR: +6%", probability: 0.021739 },
+            { name: "DEX: +6%", probability: 0.021739 },
+            { name: "INT: +6%", probability: 0.021739 },
+            { name: "LUK: +6%", probability: 0.021739 },
+            { name: "최대 HP: +6%", probability: 0.021739 },
+            { name: "최대 MP: +6%", probability: 0.021739 },
+            { name: "공격력: +6%", probability: 0.008696 },
+            { name: "마력: +6%", probability: 0.008696 },
+            { name: "크리티컬 확률: +8%", probability: 0.008696 },
+            { name: "데미지: +6%", probability: 0.008696 },
+            { name: "올스탯: +3%", probability: 0.008696 },
+            { name: "공격 시 20% 확률로 360의 HP 회복", probability: 0.008696 },
+            { name: "공격 시 20% 확률로 180의 MP 회복", probability: 0.008696 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.008696 },
+          ],
+          thirdLine: [
+            { name: "STR: +12", probability: 0.058163 },
+            { name: "DEX: +12", probability: 0.058163 },
+            { name: "INT: +12", probability: 0.058163 },
+            { name: "LUK: +12", probability: 0.058163 },
+            { name: "최대 HP: +120", probability: 0.058163 },
+            { name: "최대 MP: +120", probability: 0.058163 },
+            { name: "공격력: +12", probability: 0.038776 },
+            { name: "마력: +12", probability: 0.038776 },
+            { name: "STR: +3%", probability: 0.058163 },
+            { name: "DEX: +3%", probability: 0.058163 },
+            { name: "INT: +3%", probability: 0.058163 },
+            { name: "LUK: +3%", probability: 0.058163 },
+            { name: "공격력: +3%", probability: 0.019388 },
+            { name: "마력: +3%", probability: 0.019388 },
+            { name: "크리티컬 확률: +4%", probability: 0.019388 },
+            { name: "데미지: +3%", probability: 0.019388 },
+            { name: "올스탯: +5", probability: 0.038776 },
+            { name: "공격 시 20% 확률로 240의 HP 회복", probability: 0.019388 },
+            { name: "공격 시 20% 확률로 120의 MP 회복", probability: 0.019388 },
+            { name: "공격 시 20% 확률로 6레벨 중독효과 적용", probability: 0.019388 },
+            { name: "공격 시 10% 확률로 2레벨 기절효과 적용", probability: 0.019388 },
+            { name: "공격 시 20% 확률로 2레벨 슬로우효과 적용", probability: 0.019388 },
+            { name: "공격 시 20% 확률로 3레벨 암흑효과 적용", probability: 0.019388 },
+            { name: "공격 시 10% 확률로 2레벨 빙결효과 적용", probability: 0.019388 },
+            { name: "공격 시 10% 확률로 2레벨 봉인효과 적용", probability: 0.019388 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.019388 },
+            { name: "STR: +6%", probability: 0.005435 },
+            { name: "DEX: +6%", probability: 0.005435 },
+            { name: "INT: +6%", probability: 0.005435 },
+            { name: "LUK: +6%", probability: 0.005435 },
+            { name: "최대 HP: +6%", probability: 0.005435 },
+            { name: "최대 MP: +6%", probability: 0.005435 },
+            { name: "공격력: +6%", probability: 0.002174 },
+            { name: "마력: +6%", probability: 0.002174 },
+            { name: "크리티컬 확률: +8%", probability: 0.002174 },
+            { name: "데미지: +6%", probability: 0.002174 },
+            { name: "올스탯: +3%", probability: 0.002174 },
+            { name: "공격 시 20% 확률로 360의 HP 회복", probability: 0.002174 },
+            { name: "공격 시 20% 확률로 180의 MP 회복", probability: 0.002174 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.002174 },
+          ],
+        },
+      },
+      유니크: {
+        "120": {
+          firstLine: [
+            { name: "STR: +9%", probability: 0.116279 },
+            { name: "DEX: +9%", probability: 0.116279 },
+            { name: "INT: +9%", probability: 0.116279 },
+            { name: "LUK: +9%", probability: 0.116279 },
+            { name: "공격력: +9%", probability: 0.069767 },
+            { name: "마력: +9%", probability: 0.069767 },
+            { name: "크리티컬 확률: +9%", probability: 0.093023 },
+            { name: "데미지: +9%", probability: 0.069767 },
+            { name: "올스탯: +6%", probability: 0.093023 },
+            { name: "몬스터 방어율 무시: +30%", probability: 0.069767 },
+            { name: "보스 몬스터 공격 시 데미지: +30%", probability: 0.069767 },
+          ],
+          secondLine: [
+            { name: "STR: +6%", probability: 0.086957 },
+            { name: "DEX: +6%", probability: 0.086957 },
+            { name: "INT: +6%", probability: 0.086957 },
+            { name: "LUK: +6%", probability: 0.086957 },
+            { name: "최대 HP: +6%", probability: 0.086957 },
+            { name: "최대 MP: +6%", probability: 0.086957 },
+            { name: "공격력: +6%", probability: 0.034783 },
+            { name: "마력: +6%", probability: 0.034783 },
+            { name: "크리티컬 확률: +8%", probability: 0.034783 },
+            { name: "데미지: +6%", probability: 0.034783 },
+            { name: "올스탯: +3%", probability: 0.034783 },
+            { name: "공격 시 20% 확률로 360의 HP 회복", probability: 0.034783 },
+            { name: "공격 시 20% 확률로 180의 MP 회복", probability: 0.034783 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.034783 },
+            { name: "STR: +9%", probability: 0.023256 },
+            { name: "DEX: +9%", probability: 0.023256 },
+            { name: "INT: +9%", probability: 0.023256 },
+            { name: "LUK: +9%", probability: 0.023256 },
+            { name: "공격력: +9%", probability: 0.013953 },
+            { name: "마력: +9%", probability: 0.013953 },
+            { name: "크리티컬 확률: +9%", probability: 0.018605 },
+            { name: "데미지: +9%", probability: 0.013953 },
+            { name: "올스탯: +6%", probability: 0.018605 },
+            { name: "몬스터 방어율 무시: +30%", probability: 0.013953 },
+            { name: "보스 몬스터 공격 시 데미지: +30%", probability: 0.013953 },
+          ],
+          thirdLine: [
+            { name: "STR: +6%", probability: 0.103261 },
+            { name: "DEX: +6%", probability: 0.103261 },
+            { name: "INT: +6%", probability: 0.103261 },
+            { name: "LUK: +6%", probability: 0.103261 },
+            { name: "최대 HP: +6%", probability: 0.103261 },
+            { name: "최대 MP: +6%", probability: 0.103261 },
+            { name: "공격력: +6%", probability: 0.041304 },
+            { name: "마력: +6%", probability: 0.041304 },
+            { name: "크리티컬 확률: +8%", probability: 0.041304 },
+            { name: "데미지: +6%", probability: 0.041304 },
+            { name: "올스탯: +3%", probability: 0.041304 },
+            { name: "공격 시 20% 확률로 360의 HP 회복", probability: 0.041304 },
+            { name: "공격 시 20% 확률로 180의 MP 회복", probability: 0.041304 },
+            { name: "몬스터 방어율 무시: +15%", probability: 0.041304 },
+            { name: "STR: +9%", probability: 0.005814 },
+            { name: "DEX: +9%", probability: 0.005814 },
+            { name: "INT: +9%", probability: 0.005814 },
+            { name: "LUK: +9%", probability: 0.005814 },
+            { name: "공격력: +9%", probability: 0.003488 },
+            { name: "마력: +9%", probability: 0.003488 },
+            { name: "크리티컬 확률: +9%", probability: 0.004651 },
+            { name: "데미지: +9%", probability: 0.003488 },
+            { name: "올스탯: +6%", probability: 0.004651 },
+            { name: "몬스터 방어율 무시: +30%", probability: 0.003488 },
+            { name: "보스 몬스터 공격 시 데미지: +30%", probability: 0.003488 },
+          ],
+        },
+      },
+      레전드리: {
+        "120": {
+          firstLine: [
+            { name: "STR: +12%", probability: 0.097561 },
+            { name: "DEX: +12%", probability: 0.097561 },
+            { name: "INT: +12%", probability: 0.097561 },
+            { name: "LUK: +12%", probability: 0.097561 },
+            { name: "공격력: +12%", probability: 0.04878 },
+            { name: "마력: +12%", probability: 0.04878 },
+            { name: "크리티컬 확률: +12%", probability: 0.04878 },
+            { name: "데미지: +12%", probability: 0.04878 },
+            { name: "올스탯: +9%", probability: 0.073171 },
+            { name: "공격력: +32", probability: 0.04878 },
+            { name: "마력: +32", probability: 0.04878 },
+            { name: "몬스터 방어율 무시: +35%", probability: 0.04878 },
+            { name: "몬스터 방어율 무시: +40%", probability: 0.04878 },
+            { name: "보스 몬스터 공격 시 데미지: +35%", probability: 0.097561 },
+            { name: "보스 몬스터 공격 시 데미지: +40%", probability: 0.04878 },
+          ],
+          secondLine: [
+            { name: "STR: +9%", probability: 0.093023 },
+            { name: "DEX: +9%", probability: 0.093023 },
+            { name: "INT: +9%", probability: 0.093023 },
+            { name: "LUK: +9%", probability: 0.093023 },
+            { name: "공격력: +9%", probability: 0.055814 },
+            { name: "마력: +9%", probability: 0.055814 },
+            { name: "크리티컬 확률: +9%", probability: 0.074419 },
+            { name: "데미지: +9%", probability: 0.055814 },
+            { name: "올스탯: +6%", probability: 0.074419 },
+            { name: "몬스터 방어율 무시: +30%", probability: 0.055814 },
+            { name: "보스 몬스터 공격 시 데미지: +30%", probability: 0.055814 },
+            { name: "STR: +12%", probability: 0.019512 },
+            { name: "DEX: +12%", probability: 0.019512 },
+            { name: "INT: +12%", probability: 0.019512 },
+            { name: "LUK: +12%", probability: 0.019512 },
+            { name: "공격력: +12%", probability: 0.009756 },
+            { name: "마력: +12%", probability: 0.009756 },
+            { name: "크리티컬 확률: +12%", probability: 0.009756 },
+            { name: "데미지: +12%", probability: 0.009756 },
+            { name: "올스탯: +9%", probability: 0.014634 },
+            { name: "공격력: +32", probability: 0.009756 },
+            { name: "마력: +32", probability: 0.009756 },
+            { name: "몬스터 방어율 무시: +35%", probability: 0.009756 },
+            { name: "몬스터 방어율 무시: +40%", probability: 0.009756 },
+            { name: "보스 몬스터 공격 시 데미지: +35%", probability: 0.019512 },
+            { name: "보스 몬스터 공격 시 데미지: +40%", probability: 0.009756 },
+          ],
+          thirdLine: [
+            { name: "STR: +9%", probability: 0.110465 },
+            { name: "DEX: +9%", probability: 0.110465 },
+            { name: "INT: +9%", probability: 0.110465 },
+            { name: "LUK: +9%", probability: 0.110465 },
+            { name: "공격력: +9%", probability: 0.066279 },
+            { name: "마력: +9%", probability: 0.066279 },
+            { name: "크리티컬 확률: +9%", probability: 0.088372 },
+            { name: "데미지: +9%", probability: 0.066279 },
+            { name: "올스탯: +6%", probability: 0.088372 },
+            { name: "몬스터 방어율 무시: +30%", probability: 0.066279 },
+            { name: "보스 몬스터 공격 시 데미지: +30%", probability: 0.066279 },
+            { name: "STR: +12%", probability: 0.004878 },
+            { name: "DEX: +12%", probability: 0.004878 },
+            { name: "INT: +12%", probability: 0.004878 },
+            { name: "LUK: +12%", probability: 0.004878 },
+            { name: "공격력: +12%", probability: 0.002439 },
+            { name: "마력: +12%", probability: 0.002439 },
+            { name: "크리티컬 확률: +12%", probability: 0.002439 },
+            { name: "데미지: +12%", probability: 0.002439 },
+            { name: "올스탯: +9%", probability: 0.003659 },
+            { name: "공격력: +32", probability: 0.002439 },
+            { name: "마력: +32", probability: 0.002439 },
+            { name: "몬스터 방어율 무시: +35%", probability: 0.002439 },
+            { name: "몬스터 방어율 무시: +40%", probability: 0.002439 },
+            { name: "보스 몬스터 공격 시 데미지: +35%", probability: 0.004878 },
+            { name: "보스 몬스터 공격 시 데미지: +40%", probability: 0.002439 },
+          ],
+        },
+      },
+    },
+  };
+
+  return optionPools[itemType][itemGrade][itemLevel] || { firstLine: [], secondLine: [], thirdLine: [] };
+}


### PR DESCRIPTION
- 큐브(잠재능력 재설정) 시뮬레이터 추가
  - 현재는 임시로 장비 아이템 중 '무기'에만 큐브 시뮬레이터 가능
  - 이후 다른 페이지에서도 사용 가능하게끔 class 형태로 시뮬레이터를 구현함

이후 필요한 작업
- 잠재능력 옵션/확률 데이터 추가